### PR TITLE
Improve README explanations

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -112,7 +112,7 @@ echo "import model EWdim6-full" | python2 software/MG5_aMC_v2_6_7/bin/mg5_aMC
 
 
 ### 6. Install Numpy on Python2
-Finally, as some of the MadGraph package use _Fortran_ code internally, an additional binary 
+Finally, as some MadGraph packages use _Fortran_ code internally, an additional binary 
 need to be installed. The binary is used to create _Fortran_ to Python interfaces,
 it is called `f2py`, and it is distributed by [Numpy][numpy-website].
 
@@ -132,5 +132,5 @@ pip2 install numpy
 [pythia-website]: http://home.thep.lu.se/Pythia/
 [sip-docs]: https://en.wikipedia.org/wiki/System_Integrity_Protection
 [sip-guide]: https://ss64.com/osx/csrutil.html
-[root-guide]: https://root.cern.ch/building-root#quick-start
+[root-guide]: https://root.cern/install/build_from_source/#quick-start
 [root-website]: https://root.cern.ch/

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ over a set of utilities that are used to coordinate workflows. Please consider t
 to define Yadage workflows as the [Yadage documentation][yadage-docs] is incomplete.
 For learning about Yadage hidden features contact [Lukas Heinrich][lukas-profile], Yadage creator.
 
-Yadage depends on having a Docker image used as environment already published. For publishing the Docker
-image for this workflow jump to the [Docker section](#docker).
+Yadage depends on having the Docker image used as environment already available on DockerHub. For pushing the
+Docker image for this workflow, jump to the [Docker section](#docker).
 
-Once the Docker image is published:
+Once the Docker image has been pushed:
 ```shell script
 pip3 install yadage
 make yadage-run
@@ -101,12 +101,12 @@ make yadage-run
 
 
 ## Docker
-To build a new Docker image for local testing:
+To build a new Docker image:
 ```shell script
 make build
 ```
 
-To publish a new Docker image, bump up the `VERSION` number and execute:
+To push a new Docker image, bump up the `VERSION` number and execute:
 
 ```shell script
 export DOCKERUSER=<your_dockerhub_username>


### PR DESCRIPTION
This PR improves README Docker interaction explanations, and fixes an old [ROOT](https://root.cern/) link.